### PR TITLE
Store ciphertext for AR-encrypted columns

### DIFF
--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -5,8 +5,15 @@ ActiveRecord::Base.establish_connection adapter: "sqlite3", database: ":memory:"
 
 ActiveRecord.use_yaml_unsafe_load = true
 
+ActiveRecord::Encryption.configure(
+  primary_key: 'abc123',
+  deterministic_key: 'def456',
+  key_derivation_salt: 'ghi789',
+)
+
 ActiveRecord::Migration.create_table :widgets do |t|
   t.string :name
+  t.string :token, limit: 510
   t.integer :price
   t.string :original_name 
   t.timestamps

--- a/spec/support/widget.rb
+++ b/spec/support/widget.rb
@@ -5,6 +5,8 @@ class Widget < ActiveRecord::Base
   validates :name, presence: true
   before_create :set_original_name
   
+  encrypts :token
+
   def rename(new_name)
     self.update(name: new_name)
   end


### PR DESCRIPTION
This PR adds support for [ActiveRecord encryption](https://guides.rubyonrails.org/active_record_encryption.html). Before this PR, encrypted attributes were stored in plaintext as part of `requested_changes`. With this PR, the ciphertext is stored, but deserialized when `requested_changes` is accessed.

See also https://github.com/financeit/financeit/pull/28951 for more context.